### PR TITLE
One-click Payment methods in agent-app-sdk

### DIFF
--- a/.changeset/tricky-trainers-lick.md
+++ b/.changeset/tricky-trainers-lick.md
@@ -1,0 +1,5 @@
+---
+"@livechat/agent-app-sdk": minor
+---
+
+Added `startDirectCharge` and `startRecurrentCharge` for starting the one-click payment process

--- a/packages/agent-app-sdk/src/widgets/details/details-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/details/details-widget.ts
@@ -1,17 +1,9 @@
-import {
-  createWidget,
-  withAmplitude,
-  createConnection,
-  IConnection
-} from '@livechat/widget-core-sdk';
+import { createConnection, createWidget, IConnection, withAmplitude } from '@livechat/widget-core-sdk';
 import { withCustomerProfile } from '../shared/customer-profile';
 import { withRichMessages } from '../shared/rich-messages';
+import { withTransactions } from '../shared/transactions';
 import assertSection from './custom-sections';
-import {
-  IDetailsWidgetEvents,
-  IDetailsWidgetApi,
-  ISection
-} from './interfaces';
+import { IDetailsWidgetApi, IDetailsWidgetEvents, ISection } from './interfaces';
 
 export function DetailsWidget(connection: IConnection<IDetailsWidgetEvents>) {
   const base = createWidget<IDetailsWidgetApi, IDetailsWidgetEvents>(
@@ -33,9 +25,7 @@ export function DetailsWidget(connection: IConnection<IDetailsWidgetEvents>) {
     }
   );
 
-  const widget = withAmplitude(withRichMessages(withCustomerProfile(base)));
-
-  return widget;
+  return withAmplitude(withTransactions(withRichMessages(withCustomerProfile(base))));
 }
 
 export type IDetailsWidget = ReturnType<typeof DetailsWidget>;

--- a/packages/agent-app-sdk/src/widgets/fullscreen/fullscreen-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/fullscreen/fullscreen-widget.ts
@@ -1,14 +1,6 @@
-import {
-  createWidget,
-  withAmplitude,
-  createConnection,
-  IConnection
-} from '@livechat/widget-core-sdk';
-import {
-  IFullscreenWidgetApi,
-  IFullscreenWidgetEvents,
-  ReportsFilters
-} from './interfaces';
+import { createConnection, createWidget, IConnection, withAmplitude } from '@livechat/widget-core-sdk';
+import { withTransactions } from '../shared/transactions';
+import { IFullscreenWidgetApi, IFullscreenWidgetEvents, ReportsFilters } from './interfaces';
 
 export { ReportsFilters } from './interfaces';
 
@@ -35,7 +27,7 @@ export function FullscreenWidget(
       }
     }
   );
-  return withAmplitude(base);
+  return withAmplitude(withTransactions(base));
 }
 
 export type IFullscreenWidget = ReturnType<typeof FullscreenWidget>;

--- a/packages/agent-app-sdk/src/widgets/messagebox/messagebox-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/messagebox/messagebox-widget.ts
@@ -1,16 +1,8 @@
-import {
-  createWidget,
-  withAmplitude,
-  createConnection,
-  IConnection
-} from '@livechat/widget-core-sdk';
+import { createConnection, createWidget, IConnection, withAmplitude } from '@livechat/widget-core-sdk';
 import { withCustomerProfile } from '../shared/customer-profile';
 import { withRichMessages } from '../shared/rich-messages';
-import {
-  IMessageBoxWidgetApi,
-  IMessageBoxWidgetEvents,
-  IRichMessage
-} from './interfaces';
+import { withTransactions } from '../shared/transactions';
+import { IMessageBoxWidgetApi, IMessageBoxWidgetEvents, IRichMessage } from './interfaces';
 
 export function MessageBoxWidget(
   connection: IConnection<IMessageBoxWidgetEvents>
@@ -30,7 +22,7 @@ export function MessageBoxWidget(
     }
   );
 
-  const widget = withAmplitude(withRichMessages(withCustomerProfile(base)));
+  const widget = withAmplitude(withRichMessages(withCustomerProfile(withTransactions(base))));
 
   return widget;
 }

--- a/packages/agent-app-sdk/src/widgets/settings/settings-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/settings/settings-widget.ts
@@ -1,11 +1,7 @@
-import {
-  createWidget,
-  withAmplitude,
-  createConnection,
-  IConnection
-} from '@livechat/widget-core-sdk';
-import { ISettingsWidgetApi, ISettingsWidgetEvents } from './interfaces';
+import { createConnection, createWidget, IConnection, withAmplitude } from '@livechat/widget-core-sdk';
 import { withPageData } from '../shared/page-data';
+import { withTransactions } from '../shared/transactions';
+import { ISettingsWidgetApi, ISettingsWidgetEvents } from './interfaces';
 
 export function SettingsWidget(connection: IConnection<ISettingsWidgetEvents>) {
   const base = createWidget<ISettingsWidgetApi, ISettingsWidgetEvents>(
@@ -16,7 +12,7 @@ export function SettingsWidget(connection: IConnection<ISettingsWidgetEvents>) {
       }
     }
   );
-  return withAmplitude(withPageData(base));
+  return withAmplitude(withPageData(withTransactions(base)));
 }
 
 export type ISettingsWidget = ReturnType<typeof SettingsWidget>;

--- a/packages/agent-app-sdk/src/widgets/shared/transactions/constants.ts
+++ b/packages/agent-app-sdk/src/widgets/shared/transactions/constants.ts
@@ -1,0 +1,15 @@
+export const PRODUCT = 'livechat'
+export const BILLING_API_URL = 'https://billing.livechatinc.com/v2'
+
+export enum OutgoingTransactionEvents {
+  RegisterTransactionPending = 'register_transaction_pending',
+  RegisterTransactionSuccess = 'register_transaction_success',
+  RegisterTransactionFailure = 'register_transaction_failure',
+}
+
+export enum IncomingTransactionEvents {
+  DeclineTransaction = 'decline_transaction',
+  PaymentSuccess = 'payment_success',
+  PaymentFailure = 'payment_failure',
+  UpdateBillingCycle = 'update_billing_cycle',
+}

--- a/packages/agent-app-sdk/src/widgets/shared/transactions/index.ts
+++ b/packages/agent-app-sdk/src/widgets/shared/transactions/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export { IWithTransactionsApi, withTransactions } from './transactions';
+

--- a/packages/agent-app-sdk/src/widgets/shared/transactions/interfaces.ts
+++ b/packages/agent-app-sdk/src/widgets/shared/transactions/interfaces.ts
@@ -1,0 +1,94 @@
+export enum AuthMethods {
+  Bearer = 'Bearer',
+  Basic = 'Basic',
+}
+
+export enum BillingCycle {
+  Monthly = 1,
+  Yearly = 12,
+}
+
+export enum ChargeType {
+  DirectCharge = "direct_charge",
+  RecurrentCharge = "recurrent_charge",
+}
+
+enum PaymentStatus {
+  Pending = 'pending',
+  Accepted = 'accepted',
+  Declined = 'declined',
+  Processed = 'processed',
+  Active = 'active',
+  Cancelled = 'cancelled',
+  Frozen = 'frozen',
+}
+
+type Taxes = {
+  tax_rate: number;
+  tax_value: number;
+  tax_region: string;
+  total_price: number;
+};
+
+export interface Charge {
+  id: string;
+  name: string;
+  price: number;
+  status: PaymentStatus;
+  per_account: boolean;
+  test: boolean;
+  trial_days?: number;
+  months?: BillingCycle;
+  taxes?: Taxes;
+}
+
+interface PaymentIntentMetadata<T> {
+  type: T;
+  icon: string;
+  product: string;
+  description?: string;
+  isExternalCharge: boolean;
+  hidePicker?: boolean;
+}
+
+interface PaymentIntentBase {
+  name: string;
+  price: number;
+  per_account: boolean;
+  test: boolean;
+  return_url?: string;
+}
+
+interface PaymentIntent<T> extends PaymentIntentBase {
+  metadata: PaymentIntentMetadata<T>;
+}
+
+export interface PaymentIntentDirectCharge
+  extends PaymentIntent<ChargeType.DirectCharge> {
+  quantity: number;
+}
+
+export interface PaymentIntentRecurrentCharge
+  extends PaymentIntent<ChargeType.RecurrentCharge> {
+  trial_days: number;
+  months: BillingCycle;
+}
+
+export interface DirectChargeRequest extends PaymentIntentBase {
+  icon: string;
+  description?: string;
+  quantity?: number;
+}
+
+export interface RecurrentChargeRequest extends PaymentIntentBase {
+  icon: string;
+  description?: string;
+  months?: number;
+  trial_days?: number;
+  hidePicker?: boolean;
+}
+
+export interface RequestOptions {
+  billingApiUrl?: string;
+  authMethod?: AuthMethods;
+}

--- a/packages/agent-app-sdk/src/widgets/shared/transactions/transactions.ts
+++ b/packages/agent-app-sdk/src/widgets/shared/transactions/transactions.ts
@@ -1,0 +1,68 @@
+import { WidgetMixin } from "@livechat/widget-core-sdk";
+import { BILLING_API_URL, IncomingTransactionEvents, OutgoingTransactionEvents } from './constants';
+import { AuthMethods, Charge, DirectChargeRequest, PaymentIntentDirectCharge, PaymentIntentRecurrentCharge, RecurrentChargeRequest, RequestOptions } from "./interfaces";
+import { createDirectChargeIntent, createRecurrentChargeIntent } from './utils';
+
+export interface IWithTransactionsApi {
+  startDirectCharge(token: string, request: DirectChargeRequest, options?: RequestOptions): Promise<Charge>
+  startRecurrentCharge(token: string, request: RecurrentChargeRequest, options?: RequestOptions): Promise<Charge>
+}
+
+export interface IWithTransactionsEvents {
+  [IncomingTransactionEvents.UpdateBillingCycle]: { paymentIntent: PaymentIntentRecurrentCharge, billingCycle: number }
+}
+
+export const withTransactions: WidgetMixin<
+  IWithTransactionsApi,
+  IWithTransactionsEvents
+> = widget => {
+  const createCharge = ({ paymentIntent, token, options }: {
+    paymentIntent: PaymentIntentDirectCharge | PaymentIntentRecurrentCharge;
+    options: RequestOptions;
+    token: string;
+  }): Promise<Charge> => {
+    return new Promise((resolve, reject) => {
+      const baseUrl = (options && options.billingApiUrl) ? options.billingApiUrl : BILLING_API_URL;
+      const authMethod = (options && options.authMethod) ? options.authMethod : AuthMethods.Bearer;
+      const { metadata, ...intent } = paymentIntent;
+      const url = `${baseUrl}/${metadata.type}/${metadata.product}`
+
+      widget.sendMessage(OutgoingTransactionEvents.RegisterTransactionPending, { paymentIntent });
+
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `${authMethod} ${token}`,
+        },
+        body: JSON.stringify(intent),
+      })
+        .then(response => {
+          if (!response.ok) {
+            throw new Error(`HTTP error: ${response.status}. Cannot register transaction.`);
+          }
+          return response.json();
+        })
+        .then(charge => {
+          widget.sendMessage(OutgoingTransactionEvents.RegisterTransactionSuccess, { charge });
+          resolve(charge);
+        })
+        .catch(error => {
+          widget.sendMessage(OutgoingTransactionEvents.RegisterTransactionFailure, { error });
+          reject(error);
+        });
+    });
+  };
+
+  return {
+    ...widget,
+    startDirectCharge(token: string, request: DirectChargeRequest, options?: RequestOptions): Promise<Charge> {
+      const paymentIntent = createDirectChargeIntent(request)
+      return createCharge({ paymentIntent, token, options });
+    },
+    startRecurrentCharge(token: string, request: RecurrentChargeRequest, options?: RequestOptions): Promise<Charge> {
+      const paymentIntent = createRecurrentChargeIntent(request)
+      return createCharge({ paymentIntent, token, options });
+    }
+  };
+};

--- a/packages/agent-app-sdk/src/widgets/shared/transactions/utils.ts
+++ b/packages/agent-app-sdk/src/widgets/shared/transactions/utils.ts
@@ -1,0 +1,36 @@
+import { PRODUCT } from './constants';
+import { ChargeType, DirectChargeRequest, PaymentIntentDirectCharge, PaymentIntentRecurrentCharge, RecurrentChargeRequest } from './interfaces';
+
+export const createDirectChargeIntent = (values: DirectChargeRequest): PaymentIntentDirectCharge => ({
+  name: values.name,
+  price: values.price,
+  per_account: values.per_account,
+  return_url: window.location.origin,
+  test: values.test,
+  quantity: values.quantity || 1,
+  metadata: {
+    type: ChargeType.DirectCharge,
+    product: PRODUCT,
+    isExternalCharge: true,
+    icon: values.icon,
+    description: values.description,
+  }
+})
+
+export const createRecurrentChargeIntent = (values: RecurrentChargeRequest): PaymentIntentRecurrentCharge => ({
+  name: values.name,
+  price: values.price,
+  test: values.test,
+  return_url: window.location.origin,
+  per_account: values.per_account || false,
+  months: values.months || 1,
+  trial_days: values.trial_days || 0,
+  metadata: {
+    type: ChargeType.RecurrentCharge,
+    product: PRODUCT,
+    isExternalCharge: true,
+    icon: values.icon,
+    description: values.description,
+    hidePicker: values.hidePicker,
+  }
+})


### PR DESCRIPTION
This PR adds two methods to all widgets in `agent-app-sdk`:

**startDirectCharge** - registers direct charge and sends transaction details to the OneClickPayment modal in the AA
**startRecurrentCharge** -  registers recurrent charge and sends transaction details to the OneClickPayment modal in the AA

---

**One-Click Payment** makes processing transactions quicker and more straightforward. It enables third-party developers to initiate a transaction within their applications and then transfer the transaction details to the AA. There, the end user can easily accept or decline the transaction. 

Here's preview how its going to look like:

<img width="648" alt="SCR-20240828-lwpv" src="https://github.com/user-attachments/assets/0d737360-3043-446b-bef8-4b92db4599d0">
