### PR TITLE
[MP-2044] Add support for theme data

### DIFF
--- a/.changeset/gold-swans-allow.md
+++ b/.changeset/gold-swans-allow.md
@@ -1,0 +1,5 @@
+---
+"@livechat/agent-app-sdk": minor
+---
+
+Added support for retrieving theme values via the `getTheme` method or by listening to the `change_theme` event

--- a/packages/agent-app-sdk/package.json
+++ b/packages/agent-app-sdk/package.json
@@ -28,8 +28,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.2.0",
-    "@livechat/mitt": "0.1.2",
-    "@livechat/postmessage": "^0.3.2",
     "@livechat/widget-core-sdk": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/agent-app-sdk/src/index.ts
+++ b/packages/agent-app-sdk/src/index.ts
@@ -4,4 +4,4 @@ export * from './widgets/fullscreen';
 export * from './widgets/messagebox';
 export * from './widgets/settings';
 export * from './widgets/shared/customer-profile';
-
+export * from './widgets/shared/theme';

--- a/packages/agent-app-sdk/src/widgets/details/details-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/details/details-widget.ts
@@ -1,6 +1,7 @@
 import { createConnection, createWidget, IConnection, withAmplitude, withPayments } from '@livechat/widget-core-sdk';
 import { withCustomerProfile } from '../shared/customer-profile';
 import { withRichMessages } from '../shared/rich-messages';
+import { withTheme } from '../shared/theme';
 import assertSection from './custom-sections';
 import { IDetailsWidgetApi, IDetailsWidgetEvents, ISection } from './interfaces';
 
@@ -25,7 +26,7 @@ export function DetailsWidget(connection: IConnection<IDetailsWidgetEvents>) {
     }
   );
 
-  const widget = withAmplitude(withRichMessages(withCustomerProfile(withPayments(base))));
+  const widget = withAmplitude(withRichMessages(withCustomerProfile(withTheme(withPayments(base)))));
 
   return widget;
 }

--- a/packages/agent-app-sdk/src/widgets/details/details-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/details/details-widget.ts
@@ -5,7 +5,6 @@ import { withTheme } from '../shared/theme';
 import assertSection from './custom-sections';
 import { IDetailsWidgetApi, IDetailsWidgetEvents, ISection } from './interfaces';
 
-
 export function DetailsWidget(connection: IConnection<IDetailsWidgetEvents>) {
   const base = createWidget<IDetailsWidgetApi, IDetailsWidgetEvents>(
     connection,

--- a/packages/agent-app-sdk/src/widgets/fullscreen/fullscreen-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/fullscreen/fullscreen-widget.ts
@@ -1,5 +1,6 @@
 import { createConnection, createWidget, IConnection, withAmplitude, withPayments } from '@livechat/widget-core-sdk';
 import { withPageData } from '../shared/page-data';
+import { withTheme } from '../shared/theme';
 import { IFullscreenWidgetApi, IFullscreenWidgetEvents, ReportsFilters } from './interfaces';
 
 export { ReportsFilters } from './interfaces';
@@ -28,7 +29,7 @@ export function FullscreenWidget(
     }
   );
 
-  return withAmplitude(withPageData(withPayments(base)));
+  return withAmplitude(withPageData(withTheme(withPayments(base))));
 }
 
 export type IFullscreenWidget = ReturnType<typeof FullscreenWidget>;

--- a/packages/agent-app-sdk/src/widgets/messagebox/messagebox-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/messagebox/messagebox-widget.ts
@@ -1,6 +1,7 @@
 import { createConnection, createWidget, IConnection, withAmplitude, withPayments } from '@livechat/widget-core-sdk';
 import { withCustomerProfile } from '../shared/customer-profile';
 import { withRichMessages } from '../shared/rich-messages';
+import { withTheme } from '../shared/theme';
 import { IMessageBoxWidgetApi, IMessageBoxWidgetEvents, IRichMessage } from './interfaces';
 
 export function MessageBoxWidget(
@@ -21,7 +22,7 @@ export function MessageBoxWidget(
     }
   );
 
-  const widget = withAmplitude(withRichMessages(withCustomerProfile(withPayments(base))));
+  const widget = withAmplitude(withRichMessages(withCustomerProfile(withTheme(withPayments(base)))));
 
   return widget;
 }

--- a/packages/agent-app-sdk/src/widgets/settings/settings-widget.ts
+++ b/packages/agent-app-sdk/src/widgets/settings/settings-widget.ts
@@ -1,5 +1,6 @@
 import { createConnection, createWidget, IConnection, withAmplitude, withPayments } from '@livechat/widget-core-sdk';
 import { withPageData } from '../shared/page-data';
+import { withTheme } from '../shared/theme';
 import { ISettingsWidgetApi, ISettingsWidgetEvents } from './interfaces';
 
 export function SettingsWidget(connection: IConnection<ISettingsWidgetEvents>) {
@@ -11,7 +12,7 @@ export function SettingsWidget(connection: IConnection<ISettingsWidgetEvents>) {
       }
     }
   );
-  return withAmplitude(withPageData(withPayments(base)));
+  return withAmplitude(withPageData(withTheme(withPayments(base))));
 }
 
 export type ISettingsWidget = ReturnType<typeof SettingsWidget>;

--- a/packages/agent-app-sdk/src/widgets/shared/theme.ts
+++ b/packages/agent-app-sdk/src/widgets/shared/theme.ts
@@ -1,0 +1,35 @@
+import { WidgetMixin } from '@livechat/widget-core-sdk';
+
+export type Theme = 'light' | 'dark';
+
+export interface IThemeData {
+  theme: Theme;
+}
+
+export interface IThemeApi {
+  getTheme(): Theme | null;
+}
+
+export interface IThemeEvents {
+  change_theme: IThemeData;
+}
+
+export const withTheme: WidgetMixin<
+  IThemeApi,
+  IThemeEvents
+> = widget => {
+  let theme = new URLSearchParams(window.location.search).get('theme') as Theme || null;
+
+  function onThemeChange(data: IThemeData) {
+    theme = data.theme;
+  }
+
+  widget.on('change_theme', onThemeChange);
+
+  return {
+    ...widget,
+    getTheme(): Theme | null {
+      return theme;
+    }
+  };
+};


### PR DESCRIPTION
Added support for retrieving theme values through the `getTheme` method and the `change_theme` event:

 • Each widget now includes a `getTheme` method, which will return the current parent theme value based on the initial theme specified in the widget URL via the `?theme=dark|light` query parameter and on data provided from `change_theme`.
 • Added TypeScript definitions for the `change_theme` event, which is triggered whenever the theme changes in the Agent App.