### PR TITLE
chore: add explicit workflow permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - "**"
+
+permissions: read-all
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Workflow Permissions — automated PR

GitHub Actions jobs silently inherit write access to your repository when no `permissions:` key is set. This PR locks that down by adding explicit, minimal permissions to every workflow file.

This PR was generated automatically. You own the merge — **verify CI is green first**.

---

### What was changed

- **Regular workflows** — received `permissions: read-all` at the top level (safe read-only baseline)

---


### Checklist

- [ ] CI is green (or failing jobs have been fixed with explicit job-level `permissions:`)
- [ ] **Merge into `master`**

> [!TIP]
> **`read-all` grants more access than most jobs need.** Before merging, consider narrowing it: set `permissions: {}` at the top level and add explicit grants only to jobs that need them. See [available permission scopes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).
